### PR TITLE
Add a helm chart to install tesoro

### DIFF
--- a/chart/.helmignore
+++ b/chart/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,0 +1,23 @@
+apiVersion: v2
+name: tesoro
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+appVersion: latest

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "tesoro.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "tesoro.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "tesoro.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "tesoro.labels" -}}
+helm.sh/chart: {{ include "tesoro.chart" . }}
+{{ include "tesoro.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "tesoro.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "tesoro.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "tesoro.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "tesoro.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/chart/templates/clusterrole.yaml
+++ b/chart/templates/clusterrole.yaml
@@ -1,0 +1,25 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "tesoro.fullname" . }}
+  labels:
+    {{- include "tesoro.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - events
+  - secrets
+  - configmaps
+  verbs:
+  - "*"
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - "*"

--- a/chart/templates/clusterrolebinding.yaml
+++ b/chart/templates/clusterrolebinding.yaml
@@ -1,0 +1,10 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "tesoro.fullname" . }}
+  labels:
+    {{- include "tesoro.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "tesoro.fullname" . }}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -1,0 +1,67 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "tesoro.fullname" . }}
+  labels:
+    {{- include "tesoro.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "tesoro.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "tesoro.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: 443
+              name: tesoro-api
+            - containerPort: 9095
+              name: metrics
+          args:
+            - --port=443
+            - --cert-file=/certs/cert.pem
+            - --key-file=/certs/priv.key
+          {{- with .Values.probes }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: tesoro-secrets
+              mountPath: /certs
+              readOnly: true
+      volumes:
+        - name: tesoro-secrets
+          secret:
+            secretName: {{ include "tesoro.fullname" . }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/chart/templates/mutatingwebhook_bundle.yaml
+++ b/chart/templates/mutatingwebhook_bundle.yaml
@@ -1,0 +1,52 @@
+{{ $ca := genCA "tesoro-admission-controller-ca" 3650 }}
+{{ $cn := printf "tesoro-admission-controller.%s.svc" .Release.Namespace }}
+{{ $server := genSignedCert $cn nil nil 365 $ca }}
+---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: {{ include "tesoro.fullname" . }}
+  labels:
+    {{- include "tesoro.labels" . | nindent 4 }}
+webhooks:
+  - name: {{ include "tesoro.fullname" . }}.tesoro.svc
+    failurePolicy: Fail
+    objectSelector:
+      matchLabels:
+        tesoro.kapicorp.com: enabled
+    clientConfig:
+      service:
+        name: {{ include "tesoro.fullname" . }}
+        namespace: {{ .Release.Namespace }}
+        path: "/mutate"
+      caBundle: {{ b64enc $ca.Cert }}
+    rules:
+      - operations:
+          - CREATE
+          - UPDATE
+        apiGroups:
+          - ""
+        resources:
+          - "*"
+        apiVersions:
+          - "*"
+      - operations:
+          - CREATE
+          - UPDATE
+        apiGroups:
+          - "apps"
+        resources:
+          - "deployments"
+        apiVersions:
+          - "*"
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "tesoro.fullname" . }}
+  labels:
+    {{- include "tesoro.labels" . | nindent 4 }}
+type: Opaque
+data:
+  cert.pem: {{ b64enc $server.Cert }}
+  priv.key: {{ b64enc $server.Key }}

--- a/chart/templates/service.yaml
+++ b/chart/templates/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "tesoro.fullname" . }}
+  labels:
+    {{- include "tesoro.labels" . | nindent 4 }}
+spec:
+  ports:
+    - port: 443
+      targetPort: tesoro-api
+  selector:
+    {{- include "tesoro.selectorLabels" . | nindent 4 }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,0 +1,46 @@
+# Default values for tesoro.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: kapicorp/tesoro
+  pullPolicy: Always
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: "tesoro-admission-controller"
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
## Background

When reviewing this project I found the setup details off-putting. I felt a Helm chart would make it simpler to install the software. It would also automate the details of setting up a secure self signed certificate.

## How the chart would be used

Installation is reduced to two commands:

```
kubectl create ns tesoro
helm install tesoro chart -n tesoro
```

Note:

* The helm chart supports installing tesoro into alternative namespaces.

## Testing

The example documentation can refined to use a ```k8s wait``` ensuring the admission controller is running.

```
kubectl wait --for=condition=ready pod -l app.kubernetes.io/instance=tesoro -n tesoro
```

Tests:

```
kubectl apply -f tests/k8s/nginx_deployment.yml
kubectl apply -f tests/k8s/nginx_deployment_bad.yml
```

## Known issues

This helm chart will not work on Kubernetes v1.19 

* [Kubernetes v1.19 API changes](https://kubernetes.io/docs/setup/release/notes/#api-change-1)
* [#93264](https://github.com/kubernetes/kubernetes/pull/93264)

Latest version of helm is using go 1.14

```
$ helm version
version.BuildInfo{Version:"v3.4.1", GitCommit:"c4e74854886b2efe3321e185578e6db9be0a6e29", GitTreeState:"clean", GoVersion:"go1.14.11"}
```